### PR TITLE
fix: allow warnings during USDZ conversion

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -124,12 +124,10 @@ function convertFile(filepath: string) {
 
   const stderrString = stderr.toString();
   
-  // Log warnings but don't throw
   if (stderrString) {
     logger.warn(stderrString);
   }
 
-  // Check if the output file was actually created
   const outputFile = Bun.file(output);
   if (!outputFile.exists()) {
     throw new Error("Failed to create USDZ file");

--- a/server/index.ts
+++ b/server/index.ts
@@ -122,11 +122,20 @@ function convertFile(filepath: string) {
 
   const { stderr } = Bun.spawnSync([`usd_from_gltf`, filepath, output]);
 
-  if (stderr.toString()) {
-    throw new Error(stderr.toString());
+  const stderrString = stderr.toString();
+  
+  // Log warnings but don't throw
+  if (stderrString) {
+    logger.warn(stderrString);
   }
 
-  logger.info("File converted succesfully");
+  // Check if the output file was actually created
+  const outputFile = Bun.file(output);
+  if (!outputFile.exists()) {
+    throw new Error("Failed to create USDZ file");
+  }
+
+  logger.info("File converted successfully");
 
   return `${name}.usdz`;
 }


### PR DESCRIPTION
First of all, thank you for open sourcing this.

I was getting a warning for a glb file which was failing when it shouldn't have. 

The warning was: "Warning: Texture wrap mode [S=CLAMP, T=CLAMP] unsupported on iOS viewer. Sampler(s): sampler1 [UFG_WARN_TEXTURE_WRAP_UNSUPPORTED]\nWarning: Morph targets currently unsupported. Mesh(es): EyeAO_Mesh, Eye_Mesh, ...(plus 4 more) [UFG_WARN_MORPH_TARGETS_UNSUPPORTED]\n"

This PR:
- Doesn't treat warnings as fatal errors
- Only fails if USDZ file isn't created
- Logs warnings for debugging purposes